### PR TITLE
Fix virtual environment not found error in deployment stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,10 +146,11 @@
         - image: circleci/python:3.7
       # working_directory: ~/repo
       steps:
-        # - add_ssh_keys
+        - checkout
         - run:
-            name: Deploy to GCE
+            name: Deploy to SERVER
             command: |
+                python3 -m venv venv
                 . venv/bin/activate
                 cd pollsapp/ansible
                 ansible-playbook cd_playbook.yml -i hosts.yml


### PR DESCRIPTION
Fix virtual environment not found error in deployment stage:
Virtual was not found in the working directory.